### PR TITLE
rJava support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: didehpc
 Title: DIDE HPC Support
-Version: 0.2.0
+Version: 0.2.1
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: DIDE HPC support.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: didehpc
 Title: DIDE HPC Support
-Version: 0.2.1
+Version: 0.2.2
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: DIDE HPC support.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# didehpc 0.2.1
+
+* Support adding a Java Runtime to the path. ([#58](https://github.com/mrc-ide/didehpc/pull/xx)) by `@weshinsley`
+
 # didehpc 0.2.0
 
 * Support for R 3.4.x and 3.5.x ([#54](https://github.com/mrc-ide/didehpc/issues/54))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # didehpc 0.2.1
 
-* Support adding a Java Runtime to the path. ([#58](https://github.com/mrc-ide/didehpc/pull/xx)) by `@weshinsley`
+* Support adding a Java Runtime to the path. ([#58](https://github.com/mrc-ide/didehpc/pull/59)) by `@weshinsley`
 
 # didehpc 0.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# didehpc 0.2.1
+# didehpc 0.2.2
 
 * Support adding a Java Runtime to the path. ([#58](https://github.com/mrc-ide/didehpc/pull/59)) by `@weshinsley`
 

--- a/R/batch.R
+++ b/R/batch.R
@@ -69,7 +69,9 @@ batch_templates <- function(context, config, workdir) {
               worker_timeout = config$worker_timeout,
               rrq_worker_log_path = path_worker_logs(NULL),
               log_path = path_logs(NULL),
-              cluster_name = config$cluster)
+              cluster_name = config$cluster,
+              use_java = config$use_java,
+              java_home = config$java_home)
 
   if (!linux) {
     ## NOTE: don't forget the unname()

--- a/R/config.R
+++ b/R/config.R
@@ -170,6 +170,15 @@
 ##'   library can only be used if the temporary drive is mounted on
 ##'   your computer.
 ##'
+##' @param use_java Logical, indicating if the script is going to 
+##'   require Java, for example via the rJava package. 
+##'
+##' @param java_home A string, optionally giving the path of a
+##'   custom Java Runtime Environment, which will be used if
+##'   the use_java logical is true. If left blank, then the 
+##'   default cluster Java Runtime Environment will be used.
+##'
+##'
 ##' @export
 didehpc_config <- function(credentials = NULL, home = NULL, temp = NULL,
                            cluster = NULL,
@@ -178,7 +187,8 @@ didehpc_config <- function(credentials = NULL, home = NULL, temp = NULL,
                            wholenode = NULL, parallel = NULL, hpctools = NULL,
                            workdir = NULL, use_workers = NULL, use_rrq = NULL,
                            worker_timeout = NULL, rtools = NULL,
-                           r_version = NULL, use_common_lib = NULL) {
+                           r_version = NULL, use_common_lib = NULL,
+                           use_java = NULL, java_home = NULL) {
   defaults <- didehpc_config_defaults()
   given <- list(credentials = credentials,
                 home = home,
@@ -197,7 +207,9 @@ didehpc_config <- function(credentials = NULL, home = NULL, temp = NULL,
                 worker_timeout = worker_timeout,
                 rtools = rtools,
                 r_version = r_version,
-                use_common_lib = use_common_lib)
+                use_common_lib = use_common_lib,
+                use_java = use_java,
+                java_home = java_home)
   dat <- modify_list(defaults,
                      given[!vapply(given, is.null, logical(1))])
   ## NOTE: does *not* store (or request password)
@@ -263,6 +275,13 @@ didehpc_config <- function(credentials = NULL, home = NULL, temp = NULL,
     }
     dat$common_lib <- prepare_path(p, shares)
   }
+  
+
+  if (isTRUE(dat$use_java)) {
+    if (is.null(dat$java_home)) {
+      dat$java_home <- ""
+    }
+  }
 
   ret <- list(cluster = cluster,
               credentials = dat$credentials,
@@ -280,7 +299,9 @@ didehpc_config <- function(credentials = NULL, home = NULL, temp = NULL,
               worker_timeout = dat$worker_timeout,
               rtools = dat$rtools,
               r_version = dat$r_version,
-              common_lib = dat$common_lib)
+              common_lib = dat$common_lib,
+              use_java = dat$use_java,
+              java_home = dat$java_home)
 
   class(ret) <- "didehpc_config"
   ret
@@ -333,7 +354,9 @@ didehpc_config_defaults <- function() {
     rtools         = getOption("didehpc.rtools",         FALSE),
     hpctools       = getOption("didehpc.hpctools",       FALSE),
     r_version      = getOption("didehpc.r_version",      NULL),
-    use_common_lib = getOption("didehpc.use_common_lib", FALSE))
+    use_common_lib = getOption("didehpc.use_common_lib", FALSE),
+    use_java       = getOption("didehpc.use_java",       FALSE),
+    java_home      = getOption("didehpc.java_home",      NULL))
 
 
   if (is.null(defaults$credentials)) {

--- a/inst/template_shared.bat
+++ b/inst/template_shared.bat
@@ -14,6 +14,13 @@ set CONTEXT_BOOTSTRAP=TRUE
 
 call setr{{{r_version}}}.bat
 
+REM If Java is wanted, then call setJava64.
+REM If called with blank, it adds default JRE.
+
+IF '{{{use_java}}}'=='TRUE' (
+  call setJava64.bat {{{java_home}}}
+)
+
 {{{#network_shares}}}
 ECHO mapping {{{drive}}} -^> {{{path}}}
 net use {{{drive}}} {{{path}}} /y

--- a/man/didehpc_config.Rd
+++ b/man/didehpc_config.Rd
@@ -10,7 +10,8 @@ didehpc_config(credentials = NULL, home = NULL, temp = NULL,
   shares = NULL, template = NULL, cores = NULL, wholenode = NULL,
   parallel = NULL, hpctools = NULL, workdir = NULL, use_workers = NULL,
   use_rrq = NULL, worker_timeout = NULL, rtools = NULL,
-  r_version = NULL, use_common_lib = NULL)
+  r_version = NULL, use_common_lib = NULL, use_java = NULL,
+  java_home = NULL)
 
 didehpc_config_global(...)
 }
@@ -129,6 +130,14 @@ particularly useful if using the \code{BH} package as unpacking
 that on the network drive can take a few minutes.  The common
 library can only be used if the temporary drive is mounted on
 your computer.}
+
+\item{use_java}{Logical, indicating if the script is going to 
+require Java, for example via the rJava package.}
+
+\item{java_home}{A string, optionally giving the path of a
+custom Java Runtime Environment, which will be used if
+the use_java logical is true. If left blank, then the 
+default cluster Java Runtime Environment will be used.}
 
 \item{...}{arguments to \code{didehpc_config}}
 }

--- a/vignettes/didehpc.Rmd
+++ b/vignettes/didehpc.Rmd
@@ -200,6 +200,7 @@ didehpc::didehpc_config()
 ##  - worker_timeout: 600
 ##  - rtools: FALSE
 ##  - r_version: 3.3.2
+##  - use_java: FALSE
 ```
 
 In here you can see the cluster (here, `fi--didemrchnb`),

--- a/vignettes/quickstart.Rmd
+++ b/vignettes/quickstart.Rmd
@@ -98,6 +98,7 @@ didehpc::didehpc_config()
 ##  - worker_timeout: 600
 ##  - rtools: FALSE
 ##  - r_version: 3.3.2
+##  - use_java: FALSE
 ```
 
 If this is the first time you have run this package, best to try


### PR DESCRIPTION
This seems to work!

```
options(didehpc.use_java = TRUE)
options(didehpc.java_home = "\\\\fi--san03\\homes\\wrh1\\jre")
```
(java_home here points to a JVM I made; it can be left blank to take the cluster's favourite)

```
options(didehpc.cluster = 'fi--didemrchnb')
packages <- c("rJava", "bartMachine")
ctx <- context::context_save("contexts", packages = packages, sources = "test.R")
obj <- didehpc::queue_didehpc(ctx)
t <- obj$enqueue(testj())
```
where test.R says:
```
testj <- function() {
  library(rJava)
  options(java.parameters = "-Xmx5g")
  library(bartMachine)
  paste0(getOption("java.parameters"), " : ",Sys.getenv("JAVA_HOME"))
}
```
And the result is:-

```
Welcome to bartMachine v1.2.3! You have 0.51GB memory available.

If you run out of memory, restart R, and use e.g.
'options(java.parameters = "-Xmx5g")' for 5GB of RAM before you call
'library(bartMachine)'.
```
This is fine - except that bartMachine only says we've got 0.51GB, not the 5Gb we asked for. This is because the two library commands in testj() are not actually doing anything - the libraries are already loaded by didehpc, hence the options are set too late.

The work-around for now is: after running the above once to provision the packages, set ```packages <- c()``` and recreate the context. Longer term, we should pass ```java.parameters``` formally as a configuration parameter. 