### PR TITLE
FQDN for temp and home drives

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Suggests:
     rrq (>= 0.1.0),
     syncr (>= 0.0.3),
     testthat
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0
 VignetteBuilder: knitr
 Remotes:
     mrc-ide/context,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: didehpc
 Title: DIDE HPC Support
-Version: 0.2.2
+Version: 0.2.3
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: DIDE HPC support.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-#didehpc 0.2.3
+# didehpc 0.2.3
 
 * Workaround a server share issue by using fully-qualified domain address (.dide.ic.ac.uk) for the home and temp shares. ([#61](https://github.com/mrc-ide/didehpc/pull/61)) by `@weshinsley`
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 #didehpc 0.2.3
 
-* Workaround a server share issue by using fully-qualified domain address (.dide.ic.ac.uk) for the home and temp shares. ([#60](https://github.com/mrc-ide/didehpc/pull/60)) by `@weshinsley`
+* Workaround a server share issue by using fully-qualified domain address (.dide.ic.ac.uk) for the home and temp shares. ([#61](https://github.com/mrc-ide/didehpc/pull/61)) by `@weshinsley`
 
 # didehpc 0.2.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+#didehpc 0.2.3
+
+* Workaround a server share issue by using fully-qualified domain address (.dide.ic.ac.uk) for the home and temp shares. ([#60](https://github.com/mrc-ide/didehpc/pull/60)) by `@weshinsley`
+
 # didehpc 0.2.2
 
 * Support adding a Java Runtime to the path. ([#58](https://github.com/mrc-ide/didehpc/pull/59)) by `@weshinsley`

--- a/R/config.R
+++ b/R/config.R
@@ -189,7 +189,6 @@ didehpc_config <- function(credentials = NULL, home = NULL, temp = NULL,
                            worker_timeout = NULL, rtools = NULL,
                            r_version = NULL, use_common_lib = NULL,
                            use_java = NULL, java_home = NULL) {
-
   defaults <- didehpc_config_defaults()
   given <- list(credentials = credentials,
                 home = home,
@@ -240,7 +239,6 @@ didehpc_config <- function(credentials = NULL, home = NULL, temp = NULL,
   }
   shares <- dide_detect_mount(dat$home, dat$temp, dat$shares,
                               workdir, username, cluster, FALSE)
-
   resource <- check_resources(cluster, dat$template, dat$cores,
                               dat$wholenode, dat$parallel)
 

--- a/R/config.R
+++ b/R/config.R
@@ -241,7 +241,6 @@ didehpc_config <- function(credentials = NULL, home = NULL, temp = NULL,
   shares <- dide_detect_mount(dat$home, dat$temp, dat$shares,
                               workdir, username, cluster, FALSE)
 
-
   resource <- check_resources(cluster, dat$template, dat$cores,
                               dat$wholenode, dat$parallel)
 

--- a/R/config.R
+++ b/R/config.R
@@ -189,6 +189,7 @@ didehpc_config <- function(credentials = NULL, home = NULL, temp = NULL,
                            worker_timeout = NULL, rtools = NULL,
                            r_version = NULL, use_common_lib = NULL,
                            use_java = NULL, java_home = NULL) {
+
   defaults <- didehpc_config_defaults()
   given <- list(credentials = credentials,
                 home = home,
@@ -239,6 +240,8 @@ didehpc_config <- function(credentials = NULL, home = NULL, temp = NULL,
   }
   shares <- dide_detect_mount(dat$home, dat$temp, dat$shares,
                               workdir, username, cluster, FALSE)
+
+
   resource <- check_resources(cluster, dat$template, dat$cores,
                               dat$wholenode, dat$parallel)
 

--- a/R/paths.R
+++ b/R/paths.R
@@ -37,13 +37,13 @@ prepare_path <- function(path, mappings, error = TRUE) {
 ##'   written in \code{/etc/fstab})
 ##'
 ##' @param path_remote The \emph{network path} for this drive.  It
-##'   will look something like \code{\\\\fi--didef3\\tmp\\}.
+##'   will look something like \code{\\\\fi--didef3.dide.ic.ac.uk\\tmp\\}.
 ##'   Unfortunately backslashes are really hard to get right here and
 ##'   you will need to use twice as many as you expect (so \emph{four}
 ##'   backslashes at the beginning and then two for each separator.
 ##'   If this makes you feel bad know that you are not alone:
 ##'   https://xkcd.com/1638 -- alternatively you may use forward
-##'   slashes in place of backslashes (e.g. //fi--didef3/tmp)
+##'   slashes in place of backslashes (e.g. //fi--didef3.dide.ic.ac.uk/tmp)
 ##'
 ##' @param drive_remote The place to mount the drive on the cluster.
 ##'   We're probably going to mount things at Q: and T: already so
@@ -132,11 +132,11 @@ path_worker_logs <- function(root, id = NULL) {
 dide_home <- function(path, username) {
   assert_scalar_character(username)
   assert_character(path)
-  paste0("\\\\fi--san03\\homes\\", username, "\\", gsub("/", "\\\\", path))
+  paste0("\\\\fi--san03.dide.ic.ac.uk\\homes\\", username, "\\", gsub("/", "\\\\", path))
 }
 dide_temp <- function(path) {
   assert_character(path)
-  paste0("\\\\fi--didef3\\tmp\\", "\\", gsub("/", "\\\\", path))
+  paste0("\\\\fi--didef3.dide.ic.ac.uk\\tmp\\", "\\", gsub("/", "\\\\", path))
 }
 
 detect_mount_fail <- function() {

--- a/R/paths.R
+++ b/R/paths.R
@@ -69,6 +69,28 @@ path_mapping <- function(name, path_local, path_remote, drive_remote) {
   clean_path <- function(x) {
     sub("/+$", "", gsub("\\", "/", x, fixed = TRUE))
   }
+  
+  # Make FQDN
+  
+  bits <- strsplit(path_remote,"\\\\")[[1]]
+  
+  # This contains... empty, empty, server-name, share, dir ...  
+  # So server_name should always be index 3.
+  # Remove .dide.local if we find it.
+  
+  if (grepl(".dide.local", bits[3], ignore.case = TRUE)) {
+    bits[3] <- sub(".dide.local","", bits[3], ignore.case = TRUE)
+  }
+  
+  # Add .dide.ic.ac.uk if it's not there.
+  if (!grepl(".dide.ic.ac.uk", bits[3], ignore.case = TRUE)) {
+    bits[3] <- paste0(bits[3],".dide.ic.ac.uk")
+  }
+  
+  # re_assemble
+  
+  path_remote <- paste0(bits, collapse = "\\")
+  
   ret <-
     list(name = name,
          path_remote = clean_path(path_remote),

--- a/man/didehpc_config.Rd
+++ b/man/didehpc_config.Rd
@@ -8,10 +8,10 @@
 didehpc_config(credentials = NULL, home = NULL, temp = NULL,
   cluster = NULL, build_server_host = NULL, build_server_port = NULL,
   shares = NULL, template = NULL, cores = NULL, wholenode = NULL,
-  parallel = NULL, hpctools = NULL, workdir = NULL, use_workers = NULL,
-  use_rrq = NULL, worker_timeout = NULL, rtools = NULL,
-  r_version = NULL, use_common_lib = NULL, use_java = NULL,
-  java_home = NULL)
+  parallel = NULL, hpctools = NULL, workdir = NULL,
+  use_workers = NULL, use_rrq = NULL, worker_timeout = NULL,
+  rtools = NULL, r_version = NULL, use_common_lib = NULL,
+  use_java = NULL, java_home = NULL)
 
 didehpc_config_global(...)
 }

--- a/man/path_mapping.Rd
+++ b/man/path_mapping.Rd
@@ -17,13 +17,13 @@ all, depending on what you used when you mounted it (or what is
 written in \code{/etc/fstab})}
 
 \item{path_remote}{The \emph{network path} for this drive.  It
-will look something like \code{\\\\fi--didef3\\tmp\\}.
+will look something like \code{\\\\fi--didef3.dide.ic.ac.uk\\tmp\\}.
 Unfortunately backslashes are really hard to get right here and
 you will need to use twice as many as you expect (so \emph{four}
 backslashes at the beginning and then two for each separator.
 If this makes you feel bad know that you are not alone:
 https://xkcd.com/1638 -- alternatively you may use forward
-slashes in place of backslashes (e.g. //fi--didef3/tmp)}
+slashes in place of backslashes (e.g. //fi--didef3.dide.ic.ac.uk/tmp)}
 
 \item{drive_remote}{The place to mount the drive on the cluster.
 We're probably going to mount things at Q: and T: already so

--- a/vignettes/didehpc.Rmd
+++ b/vignettes/didehpc.Rmd
@@ -75,7 +75,7 @@ and the packages will arrange for them to be saved and reloaded.
 
 The DIDE cluster needs everything to be available on a filesystem
 that the cluster can read.  Practically this means the filesystems
-`//fi--didef3/tmp` or `//fi--san03/homes/username` and the like.
+`//fi--didef3.dide.ic.ac.uk/tmp` or `//fi--san03.dide.ic.ac.uk/homes/username` and the like.
 You probably have access to network shares that are specific to a
 project, too.  For Windows users these are probably mapped to
 drives (`Q:` or `T:` or similar) already, but for other platforms
@@ -193,8 +193,8 @@ didehpc::didehpc_config()
 ##     - count: 1
 ##     - type: Cores
 ##  - shares:
-##     - home: (local) /home/rich/net/home => //fi--san03/homes/rfitzjoh => Q: (remote)
-##     - temp: (local) /home/rich/net/temp => //fi--didef3/tmp => T: (remote)
+##     - home: (local) /home/rich/net/home => //fi--san03.dide.ic.ac.uk/homes/rfitzjoh => Q: (remote)
+##     - temp: (local) /home/rich/net/temp => //fi--didef3/dide.ic.ac.uk/tmp => T: (remote)
 ##  - use_workers: FALSE
 ##  - use_rrq: FALSE
 ##  - worker_timeout: 600
@@ -225,11 +225,11 @@ which takes arguments:
   slashes are much easier to enter here than backward slashes)
 * `drive_remote`: the drive this should be mapped to on the cluster.
 
-So to map your "M drive" to which points at `\\fi--didef3\malaria`
+So to map your "M drive" to which points at `\\fi--didef3.dide.ic.ac.uk\malaria`
 to `M:` on the cluster you can write
 
 ```r
-share <- didehpc::path_mapping("malaria", "M:", "//fi--didef3/malaria", "M:")
+share <- didehpc::path_mapping("malaria", "M:", "//fi--didef3.dide.ic.ac.uk/malaria", "M:")
 config <- didehpc::didehpc_config(shares = share)
 ```
 
@@ -820,9 +820,9 @@ obj$dide_log(t)
 ## didehpc version: 0.1.1
 ## context version: 0.1.1
 ## running on: FI--DIDEMRC06
-## mapping Q: -> \\fi--san03\homes\rfitzjoh
+## mapping Q: -> \\fi--san03.dide.ic.ac.uk\homes\rfitzjoh
 ## The command completed successfully.
-## mapping T: -> \\fi--didef3\tmp
+## mapping T: -> \\fi--didef3.dide.ic.ac.uk\tmp
 ## The command completed successfully.
 ## working directory: Q:\cluster_testing\20170510\vignette
 ## this is a single task

--- a/vignettes/quickstart.Rmd
+++ b/vignettes/quickstart.Rmd
@@ -91,8 +91,8 @@ didehpc::didehpc_config()
 ##     - count: 1
 ##     - type: Cores
 ##  - shares:
-##     - home: (local) /home/rich/net/home => //fi--san03/homes/rfitzjoh => Q: (remote)
-##     - temp: (local) /home/rich/net/temp => //fi--didef3/tmp => T: (remote)
+##     - home: (local) /home/rich/net/home => //fi--san03.dide.ic.ac.uk/homes/rfitzjoh => Q: (remote)
+##     - temp: (local) /home/rich/net/temp => //fi--didef3.dide.ic.ac.uk/tmp => T: (remote)
 ##  - use_workers: FALSE
 ##  - use_rrq: FALSE
 ##  - worker_timeout: 600
@@ -408,9 +408,9 @@ obj$dide_log(t)
 ## didehpc version: 0.1.1
 ## context version: 0.1.1
 ## running on: FI--DIDEMRC06
-## mapping Q: -> \\fi--san03\homes\rfitzjoh
+## mapping Q: -> \\fi--san03.dide.ic.ac.uk\homes\rfitzjoh
 ## The command completed successfully.
-## mapping T: -> \\fi--didef3\tmp
+## mapping T: -> \\fi--didef3.dide.ic.ac.uk\tmp
 ## The command completed successfully.
 ## working directory: Q:\cluster_testing\20170510\vignette
 ## this is a single task


### PR DESCRIPTION
Hi @richfitz 

I believe this does the trick, although it is a little hard to test. It updates the default home and temp folders to include ".dide.ic.ac.uk", and also updates the path_mapping function so that the non-domain addresses returned from wmic get .dide.ic.ac.uk appended onto the server, if they don't already have them.

But I am editing this without a very good grasp of how the whole thing works; what I am treating as "success" at the moment, is that in a fresh R session, with the new package, didehpc::didehpc_config() is returning me (snipped):
 - shares:
    - home: (local) q: => //fi--san03.dide.ic.ac.uk/homes/wrh1 => Q: (remote)
    - temp: (local) T: => //fi--didef3.dide.ic.ac.uk/tmp => T: (remote)

whereas before:
 - shares:
    - home: (local) q: => //fi--san03/homes/wrh1 => Q: (remote)
    - temp: (local) T: => //fi--didef3/tmp => T: (remote)

If this propogates through to the jobs, then I think this will workaround the horrible server issue we're currently working on.
