### PR TITLE
Convert backslash to forward-slash before FQDN fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: didehpc
 Title: DIDE HPC Support
-Version: 0.2.3
+Version: 0.2.4
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: DIDE HPC support.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# didehpc 0.2.4
+
+* Fixes for different slashes for FQDN fix([#62](https://github.com/mrc-ide/didehpc/pull/62)) by `@weshinsley`
+
 # didehpc 0.2.3
 
 * Workaround a server share issue by using fully-qualified domain address (.dide.ic.ac.uk) for the home and temp shares. ([#61](https://github.com/mrc-ide/didehpc/pull/61)) by `@weshinsley`

--- a/R/paths.R
+++ b/R/paths.R
@@ -72,7 +72,7 @@ path_mapping <- function(name, path_local, path_remote, drive_remote) {
   
   # Make FQDN
   
-  bits <- strsplit(path_remote,"\\\\")[[1]]
+  bits <- strsplit(clean_path(path_remote), "/")[[1]]
   
   # This contains... empty, empty, server-name, share, dir ...  
   # So server_name should always be index 3.


### PR DESCRIPTION
Just a one-liner, to convert the incoming remote_path in path_mapping() to forward-slashed, rather than back-slashed, and then split accordingly.