### PR TITLE
Add Rtools 4.0 with usr/bin path

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: didehpc
 Title: DIDE HPC Support
-Version: 0.2.9
+Version: 0.2.10
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: DIDE HPC support.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,16 @@
-#didehpc 0.2.9
+# didehpc 0.2.10
+
+* Support for R 4.0.x with RTools 4.0
+
+# didehpc 0.2.9
 
 * Support for R 3.6.1 and future versions reported by HPC portal. See [Issue #67](https://github.com/mrc-ide/didehpc/issues/71), [mrc-481](https://vimc.myjetbrains.com/youtrack/issue/mrc-481), [PR #72](https://github.com/mrc-ide/didehpc/pull/72), [PR #73](https://github.com/mrc-ide/didehpc/pull/73)
 
-#didehpc 0.2.7
+# didehpc 0.2.7
 
 * Support for R 3.5.3. See [Issue #mrc-269](https://vimc.myjetbrains.com/youtrack/issue/mrc-269) and [PR #70](https://github.com/mrc-ide/didehpc/pull/70)) by `@weshinsley`
 
-#didehpc 0.2.6
+# didehpc 0.2.6
 
 * Support for R 3.6.0. See [Issue #67](https://github.com/mrc-ide/didehpc/issues/67) and [PR #68](https://github.com/mrc-ide/didehpc/pull/68)) by `@weshinsley`
 

--- a/R/communication.R
+++ b/R/communication.R
@@ -217,6 +217,8 @@ cluster_load_cols <- function(p, max = 1) {
   ## cols <- c("#A50026", "#D73027", "#F46D43", "#FDAE61",
   ##           "#FEE090", "#FFFFBF", "#E0F3F8", "#ABD9E9",
   ##           "#74ADD1", "#4575B4", "#313695")
+  p[is.nan(p)] <- 0
+
   cols <- c("#FED976", "#FEB24C", "#FD8D3C", "#FC4E2A", "#E31A1C", "#B10026")
   ret <- colorRamp(cols)(p / max)
   rgb(ret[, 1], ret[, 2], ret[, 3], maxColorValue = 255)

--- a/R/config.R
+++ b/R/config.R
@@ -594,18 +594,28 @@ R_BITS <- 64
 ## downloading and installation of rtools.
 rtools_versions <- function(r_version, path = NULL) {
   r_version_2 <- as.character(r_version[1, 1:2])
-  mingw <- sprintf("mingw_%d", R_BITS)
+  if (r_version < "4.0.0") {
+    mingw <- sprintf("mingw_%d", R_BITS)
+  } else {
+    mingw <- sprintf("mingw%d", R_BITS)
+  }
+  
   ret <- switch(r_version_2,
-    "3.2" = list(path = "Rtools33", gcc = "gcc-4.6.3", bin = "bin"),
-    "3.3" = list(path = "Rtools35", gcc = "gcc-4.6.3", bin = "bin"),
-    "3.4" = list(path = "Rtools35", gcc = mingw, bin = "bin"),
-    "3.5" = list(path = "Rtools35", gcc = mingw, bin = "bin"),
-    "3.6" = list(path = "Rtools35", gcc = mingw, bin = "bin"),
-    "4.0" = list(path = "Rtools40", gcc = mingw, bin = file.path("usr", "bin")),
-    stop("Get Rich to upgrade Rtools"))
+    "3.3" = list(path = "Rtools35", gcc = mingw, make = ""),
+    "3.4" = list(path = "Rtools35", gcc = mingw, make = ""),
+    "3.5" = list(path = "Rtools35", gcc = mingw, make = ""),
+    "3.6" = list(path = "Rtools35", gcc = mingw, make = ""),
+    "4.0" = list(path = "Rtools40", gcc = mingw, make = "usr"),
+    stop(sprintf("No RTools version found for R %s", r_version)))
+      
   ret$binpref <-
-    unix_path(file.path(path, "Rtools", ret$path, mingw, ret$bin))
-  ret$path <- windows_path(file_path(path, "Rtools", ret$path))
+    unix_path(file.path(path, "Rtools", ret$path, mingw, "bin"))
+  
+  ret$rtools_root <- windows_path(file_path(path, "Rtools", ret$path))
+  ret$gcc_path <- windows_path(file_path(ret$rtools_root, ret$gcc, "bin"))
+  ret$make_path <- windows_path(file_path(ret$rtools_root, ret$make, "bin"))
+  
+  ret$path <- NULL
   ret
 }
 

--- a/R/config.R
+++ b/R/config.R
@@ -170,12 +170,12 @@
 ##'   library can only be used if the temporary drive is mounted on
 ##'   your computer.
 ##'
-##' @param use_java Logical, indicating if the script is going to 
-##'   require Java, for example via the rJava package. 
+##' @param use_java Logical, indicating if the script is going to
+##'   require Java, for example via the rJava package.
 ##'
 ##' @param java_home A string, optionally giving the path of a
 ##'   custom Java Runtime Environment, which will be used if
-##'   the use_java logical is true. If left blank, then the 
+##'   the use_java logical is true. If left blank, then the
 ##'   default cluster Java Runtime Environment will be used.
 ##'
 ##'
@@ -275,7 +275,7 @@ didehpc_config <- function(credentials = NULL, home = NULL, temp = NULL,
     }
     dat$common_lib <- prepare_path(p, shares)
   }
-  
+
 
   if (isTRUE(dat$use_java)) {
     if (is.null(dat$java_home)) {
@@ -596,14 +596,15 @@ rtools_versions <- function(r_version, path = NULL) {
   r_version_2 <- as.character(r_version[1, 1:2])
   mingw <- sprintf("mingw_%d", R_BITS)
   ret <- switch(r_version_2,
-                "3.2" = list(path = "Rtools33", gcc = "gcc-4.6.3"),
-                "3.3" = list(path = "Rtools33", gcc = "gcc-4.6.3"),
-                "3.4" = list(path = "Rtools34", gcc = mingw),
-                "3.5" = list(path = "Rtools34", gcc = mingw),
-                "3.6" = list(path = "Rtools34", gcc = mingw),
-                stop("Get Rich to upgrade Rtools"))
+    "3.2" = list(path = "Rtools33", gcc = "gcc-4.6.3", bin = "bin"),
+    "3.3" = list(path = "Rtools35", gcc = "gcc-4.6.3", bin = "bin"),
+    "3.4" = list(path = "Rtools35", gcc = mingw, bin = "bin"),
+    "3.5" = list(path = "Rtools35", gcc = mingw, bin = "bin"),
+    "3.6" = list(path = "Rtools35", gcc = mingw, bin = "bin"),
+    "4.0" = list(path = "Rtools40", gcc = mingw, bin = file.path("usr", "bin")),
+    stop("Get Rich to upgrade Rtools"))
   ret$binpref <-
-    unix_path(file.path(path, "Rtools", ret$path, mingw, "bin"))
+    unix_path(file.path(path, "Rtools", ret$path, mingw, ret$bin))
   ret$path <- windows_path(file_path(path, "Rtools", ret$path))
   ret
 }
@@ -674,11 +675,11 @@ r_versions <- function(cluster) {
     numeric_version(c("3.2.4", "3.3.0", "3.3.1"))
 
   } else {
-    
+
     if (is.null(cache$r_versions)) {
       r <- httr::GET("https://mrcdata.dide.ic.ac.uk/hpc/api/v1/cluster_software/")
       v <- from_json(httr::content(r, as = "text", encoding = "UTF-8"))
-      
+
       cache$r_versions <- vcapply(
         v$software[vlapply(v$software, function(x) x$name == 'R')], "[[", "version")
 

--- a/inst/template_shared.bat
+++ b/inst/template_shared.bat
@@ -27,8 +27,8 @@ net use {{{drive}}} {{{path}}} /y
 {{{/network_shares}}}
 
 {{{#rtools}}}
-ECHO Using Rtools at {{{rtools.path}}}
-set PATH={{{rtools.path}}}\bin;{{{rtools.path}}}\{{{rtools.gcc}}}\bin;%PATH%
+ECHO Using Rtools at {{{rtools.rtools_root}}}
+set PATH={{{rtools.gcc_path}}};{{{rtools.make_path}}};%PATH%
 set BINPREF={{{rtools.binpref}}}/
 {{{/rtools}}}
 


### PR DESCRIPTION
Ok, here's a start at getting R 4.0 / rtools40 running. 

R 3.6.3 and R 4.0.2 are present on both clusters - json updated [here](https://mrcdata.dide.ic.ac.uk/hpc/api/v1/cluster_software/)

RTools 4.0 is present in T:\Rtools\Rtools40

This PR updates the list of required Rtools versions to match those [here](https://cran.r-project.org/bin/windows/Rtools/history.html) - also noting that the path to bin is different for Rtools40. 

Also, R 3.6.3 and 4.0.2 are installed on the build server...

Probably more to do to finish this...
