### PR TITLE
Make verylazy even lazier

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: didehpc
 Title: DIDE HPC Support
-Version: 0.3.1
+Version: 0.3.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# didehpc 0.3.2
+
+* The "verylazy" provisioning policy does not tell pkgdepends about already present packages, which avoids some issues where a library has been manually tweaked using `$install_packages()` (#88)
+
 # didehpc 0.3.1
 
 * rrq worker resource configuration may differ from the normal task resource requirements (#83)

--- a/R/queue_didehpc.R
+++ b/R/queue_didehpc.R
@@ -253,19 +253,21 @@ queue_didehpc_ <- R6::R6Class(
       } else {
         needs_rrq <- self$config$use_rrq || self$config$use_workers
         dat <- context_packages(self$context, needs_rrq)
-        complete <- private$lib$check(dat$packages)$complete
+        status <- private$lib$check(dat$packages)
+        packages <- dat$packages
         run_provision <- TRUE
         if (policy == "verylazy") {
           policy <- "lazy"
-          run_provision <- !complete
-          if (complete && !quiet) {
+          run_provision <- !status$complete
+          packages <- status$missing
+          if (!run_provision && !quiet) {
             message("Nothing to install; try running with policy = 'upgrade'")
           }
         }
       }
 
       if (run_provision) {
-        self$install_packages(dat$packages, dat$repos, policy, dryrun,
+        self$install_packages(packages, dat$repos, policy, dryrun,
                               show_progress, show_log)
       }
 


### PR DESCRIPTION
As seen with @RaphaelS1, we might want to tell pkgdepends about the smallest number of packages to update as we can end up with locking problems. This PR updates the "verylazy" policy to only try and inspect packages that are missing, which will make the manual package installation with `$install_packages()` more useful

Fixes #88