### PR TITLE
Update to use current rrq

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: didehpc
 Title: DIDE HPC Support
-Version: 0.3.4
+Version: 0.3.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),
@@ -34,7 +34,7 @@ Suggests:
     pkgdepends (>= 0.1.0),
     redux,
     rmarkdown,
-    rrq (>= 0.3.0),
+    rrq (>= 0.4.3),
     testthat,
     withr
 RoxygenNote: 7.1.1

--- a/R/rrq.R
+++ b/R/rrq.R
@@ -97,7 +97,7 @@ rrq_submit_workers <- function(obj, data, n, timeout = 600,
 
   dir.create(data$paths$local$batch, FALSE, TRUE)
   dir.create(data$paths$local$worker_log, FALSE, TRUE)
-  rrq:::write_rrq_worker(file.path(data$paths$local$root, "bin"))
+  rrq:::rrq_worker_script(file.path(data$paths$local$root, "bin"))
   for (nm in names) {
     dat <- list(rrq_worker_id = nm, rrq_key_alive = rrq_key_alive)
     base <- paste0(nm, ".bat")


### PR DESCRIPTION
Eliminates a warning when setting up rrq workers