### PR TITLE
Fix reconcile when tasks are named

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: didehpc
 Title: DIDE HPC Support
-Version: 0.3.6
+Version: 0.3.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/reconcile.R
+++ b/R/reconcile.R
@@ -37,6 +37,13 @@ reconcile_compare <- function(obj, task_ids = NULL) {
   dat <- obj$client$status_user("*", obj$config$cluster)
   message("  ...done")
 
+  ## If tasks have been created in a group with names per-task, then
+  ## we need to do a bit of processing to get the actual id. We
+  ## construct these names as "%s (%s)" so this regex should always
+  ## work:
+  re <- "^.+\\(([[:xdigit:]]{32})\\)$"
+  dat$name <- sub(re, "\\1", dat$name)
+
   i <- match(task_ids, dat$name)
   st_hpc <- dat$status[i]
 


### PR DESCRIPTION
As reported by @ojwatson in #99, this copes with reconciliation with named tasks.

This is still inadequately tested and there's logic to work through (e.g., #69 remains, and conan jobs might cause issues) but this should do the trick for now