### PR TITLE
Add R 4.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: didehpc
 Title: DIDE HPC Support
-Version: 0.3.12
+Version: 0.3.13
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: didehpc
 Title: DIDE HPC Support
-Version: 0.3.13
+Version: 0.3.14
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# didehpc 0.3.13
+# didehpc 0.3.14
 
 Support for R 4.2.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# didehpc 0.3.13
+
+Support for R 4.2.1
+
 # didehpc 0.3.12
 
 Fix failure to build from source due to BINPREF wrongly set.

--- a/R/batch.R
+++ b/R/batch.R
@@ -55,8 +55,6 @@ template_data <- function(context_root, context_id, config, workdir) {
     conan_path_bootstrap <- NULL
   }
 
-  rtools <- rtools_versions(temp_drive, config$r_version)
-
   list(hostname = hostname(),
        date = as.character(Sys.Date()),
        didehpc_version = as.character(packageVersion("didehpc")),
@@ -71,7 +69,6 @@ template_data <- function(context_root, context_id, config, workdir) {
        context_id = context_id,
        conan_path_bootstrap = conan_path_bootstrap,
        r_libs_user = r_libs_user,
-       rtools = rtools,
        parallel = parallel,
        redis_host = redis_host(config$cluster),
        rrq_key_alive = config$rrq_key_alive,

--- a/R/config.R
+++ b/R/config.R
@@ -460,57 +460,6 @@ check_worker_resource <- function(worker_resource, cluster, template,
                              call. = FALSE))
 }
 
-
-## TODO: document how updates happen as there's some manual
-## downloading and installation of rtools.
-rtools_versions <- function(path, r_version) {
-  r_version_2 <- as.character(r_version[1, 1:2])
-  
-  # R before 4.0.0
-  if (r_version < "4.0.0") {
-    mingw <- "mingw_%R_BITS%"
-    binpref_mingw <- "mingw_$(WIN)"
- 
-  # R 4.0.0 - 4.1.x
-  
-  } else if (r_version < "4.2.0") {
-    mingw <- "mingw%R_BITS%"
-    binpref_mingw <- "mingw$(WIN)"
-  
-  # R 4.2.x
-    
-  } else {
-    mingw <- "x86_64-w64-mingw32.static.posix"
-    binpref_mingw <- "x86_64-w64-mingw32.static.posix"
-  }
-
-
-  ret <- switch(r_version_2,
-                "3.3" = list(path = "Rtools35", gcc = mingw, make = ""),
-                "3.4" = list(path = "Rtools35", gcc = mingw, make = ""),
-                "3.5" = list(path = "Rtools35", gcc = mingw, make = ""),
-                "3.6" = list(path = "Rtools35", gcc = mingw, make = ""),
-                "4.0" = list(path = "Rtools40", gcc = mingw, make = "usr"),
-                "4.1" = list(path = "Rtools40", gcc = mingw, make = "usr"),
-                "4.2" = list(path = "Rtools42", gcc = mingw, make = "usr"),
-                stop(sprintf("No RTools version found for R %s", r_version)))
-
-  ret$binpref <-
-    unix_path(file.path(path, "Rtools", ret$path, binpref_mingw, "bin"))
-  
-  if (r_version_2 == "4.2") {
-    ret$binpref <- paste0(ret$binpref, "/")
-  }
-
-  ret$rtools_root <- windows_path(file_path(path, "Rtools", ret$path))
-  ret$gcc_path <- windows_path(file_path(ret$rtools_root, ret$gcc, "bin"))
-  ret$make_path <- windows_path(file_path(ret$rtools_root, ret$make, "bin"))
-
-  ret$path <- NULL
-  ret
-}
-
-
 redis_host <- function(cluster) {
   switch(cluster,
          "wpia-hpc-hn" = "12.0.1.254",

--- a/R/config.R
+++ b/R/config.R
@@ -465,13 +465,25 @@ check_worker_resource <- function(worker_resource, cluster, template,
 ## downloading and installation of rtools.
 rtools_versions <- function(path, r_version) {
   r_version_2 <- as.character(r_version[1, 1:2])
+  
+  # R before 4.0.0
   if (r_version < "4.0.0") {
     mingw <- "mingw_%R_BITS%"
     binpref_mingw <- "mingw_$(WIN)"
-  } else {
+ 
+  # R 4.0.0 - 4.1.x
+  
+  } else if (r_version < "4.2.0") {
     mingw <- "mingw%R_BITS%"
     binpref_mingw <- "mingw$(WIN)"
+  
+  # R 4.2.x
+    
+  } else {
+    mingw <- "x86_64-w64-mingw32.static.posix"
+    binpref_mingw <- "x86_64-w64-mingw32.static.posix"
   }
+
 
   ret <- switch(r_version_2,
                 "3.3" = list(path = "Rtools35", gcc = mingw, make = ""),
@@ -485,6 +497,10 @@ rtools_versions <- function(path, r_version) {
 
   ret$binpref <-
     unix_path(file.path(path, "Rtools", ret$path, binpref_mingw, "bin"))
+  
+  if (r_version_2 == "4.2") {
+    ret$binpref <- paste0(ret$binpref, "/")
+  }
 
   ret$rtools_root <- windows_path(file_path(path, "Rtools", ret$path))
   ret$gcc_path <- windows_path(file_path(ret$rtools_root, ret$gcc, "bin"))

--- a/R/config.R
+++ b/R/config.R
@@ -480,6 +480,7 @@ rtools_versions <- function(path, r_version) {
                 "3.6" = list(path = "Rtools35", gcc = mingw, make = ""),
                 "4.0" = list(path = "Rtools40", gcc = mingw, make = "usr"),
                 "4.1" = list(path = "Rtools40", gcc = mingw, make = "usr"),
+                "4.2" = list(path = "Rtools42", gcc = mingw, make = "usr"),
                 stop(sprintf("No RTools version found for R %s", r_version)))
 
   ret$binpref <-

--- a/inst/template_conan.bat
+++ b/inst/template_conan.bat
@@ -9,10 +9,6 @@ call setr64_{{r_version}}.bat
 
 {{network_shares_create}}
 
-ECHO Using Rtools at {{rtools$rtools_root}}
-set PATH={{rtools$gcc_path}};{{rtools$make_path}};%PATH%
-set BINPREF={{rtools$binpref}}/
-
 set CONAN_PATH_BOOTSTRAP={{conan_path_bootstrap}}
 set CONAN_PATH_CACHE={{context_root}}\conan\cache
 

--- a/inst/template_shared.bat
+++ b/inst/template_shared.bat
@@ -10,9 +10,6 @@ set CONTEXT_WORKDIR={{context_workdir}}
 set CONTEXT_ROOT={{context_root}}
 set CONTEXT_ID={{context_id}}
 set R_LIBS_USER={{r_libs_user}}
-set RTOOLS35_HOME=T:\Rtools\Rtools35
-set RTOOLS40_HOME=T:\Rtools\Rtools40
-set RTOOLS42_HOME=T:\Rtools\Rtools42
 
 call setr64_{{r_version}}.bat
 
@@ -24,10 +21,6 @@ IF '{{use_java}}'=='TRUE' (
 )
 
 {{network_shares_create}}
-
-ECHO Using Rtools at {{rtools$rtools_root}}
-set PATH={{rtools$gcc_path}};{{rtools$make_path}};%PATH%
-set BINPREF={{rtools$binpref}}/
 
 {{parallel}}
 

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -136,35 +136,6 @@ test_that("Can find redis host, given cluster", {
 })
 
 
-test_that("Can get a reasonable rtools version", {
-  expect_equal(
-    rtools_versions("<prefix>", numeric_version("4.0.0")),
-    list(gcc = "mingw%R_BITS%",
-         make = "usr",
-         binpref = "<prefix>/Rtools/Rtools40/mingw$(WIN)/bin",
-         rtools_root = "<prefix>\\Rtools\\Rtools40",
-         gcc_path = "<prefix>\\Rtools\\Rtools40\\mingw%R_BITS%\\bin",
-         make_path = "<prefix>\\Rtools\\Rtools40\\usr\\bin"))
-  expect_equal(
-    rtools_versions("<prefix>", numeric_version("3.6.3")),
-    list(gcc = "mingw_%R_BITS%",
-         make = "",
-         binpref = "<prefix>/Rtools/Rtools35/mingw_$(WIN)/bin",
-         rtools_root = "<prefix>\\Rtools\\Rtools35",
-         gcc_path = "<prefix>\\Rtools\\Rtools35\\mingw_%R_BITS%\\bin",
-         make_path = "<prefix>\\Rtools\\Rtools35\\\\bin"))
-  expect_equal(
-    rtools_versions("<prefix>", numeric_version("3.5.0")),
-    rtools_versions("<prefix>", numeric_version("3.6.0")))
-  expect_equal(
-    rtools_versions("<prefix>", numeric_version("3.4.3")),
-    rtools_versions("<prefix>", numeric_version("3.5.0")))
-  expect_equal(
-    rtools_versions("<prefix>", numeric_version("3.3.3")),
-    rtools_versions("<prefix>", numeric_version("3.5.0")))
-})
-
-
 test_that("fetch r versions", {
   testthat::skip_if_offline()
   dat <- r_versions()


### PR DESCRIPTION
@richfitz  - I think this is it, although was expecting slightly more of a fight with it. There won't be a setr32_4_2_1.bat on any cluster nodes, but that doesn't seem to require any change. inst/template_conan.bat and template_shared.bat already depend only on r64...

So I think this is will all be ok, but I don't exactly understand (or have forgotten) where the request to build 32-bit versions of packages used to come from, or whether that will have magically disappeared when R 4.2.x is the version selected.