### PR TITLE
Exclude base packages from install

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: didehpc
 Title: DIDE HPC Support
-Version: 0.3.14
+Version: 0.3.15
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/queue_didehpc.R
+++ b/R/queue_didehpc.R
@@ -402,15 +402,23 @@ context_packages <- function(context, need_rrq = FALSE) {
   ## 'callr' is needed if using 'rrq' because the rrq/context queue
   ## runs things in separate processes using callr, but this is only
   ## an optional dependency.
-  list(packages = unique(c("context",
-                           if (need_rrq) c("rrq", "callr"),
-                           context$packages$attached,
-                           context$packages$loaded,
-                           context$package_sources$packages)),
-       repos = c(context$package_sources$repos,
-                 didehpc = "https://mrc-ide.github.io/didehpc-pkgs"))
+  packages <- setdiff(unique(c("context",
+                               if (need_rrq) c("rrq", "callr"),
+                               context$packages$attached,
+                               context$packages$loaded,
+                               context$package_sources$packages)),
+                      builtin_packages())
+  repos <- c(context$package_sources$repos,
+             didehpc = "https://mrc-ide.github.io/didehpc-pkgs")
+  list(packages = packages,
+       repos = repos)
 }
 
+
+builtin_packages <- function() {
+  rownames(installed.packages(priority = "high"))
+}
+c
 
 task_names <- function(task_ids, names) {
   if (is.null(names)) {

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -188,6 +188,18 @@ test_that("Can get all context packages", {
 })
 
 
+test_that("Can exclude base packages from install", {
+  root <- tempfile()
+  repos <- c(didehpc = "https://mrc-ide.github.io/didehpc-pkgs")
+  ctx <- context::context_save(root, packages = c("base", "utils", "foo"))
+  expect_equal(context_packages(ctx),
+               list(packages = c("context", "foo"), repos = repos))
+  expect_equal(context_packages(ctx, TRUE),
+               list(packages = c("context", "rrq", "callr", "foo"),
+                    repos = repos))
+})
+
+
 test_that("Can get all context packages where loaded is used", {
   root <- tempfile()
   repos <- c(didehpc = "https://mrc-ide.github.io/didehpc-pkgs")


### PR DESCRIPTION
As seen with @Dariyanikitin's installation, we get bad error messages and annoying behaviour if packages like 'utils' are explicitly included in the installation. This PR excludes them from being passed to conan, but means that context will still load them (which is the desired behaviour for recommended-but-not-default packages like MASS)